### PR TITLE
feat: add compatibility with node 14+

### DIFF
--- a/lib/pipes/writeFiles.ts
+++ b/lib/pipes/writeFiles.ts
@@ -23,7 +23,7 @@ export async function writeResult(i: PostcssPipeResult, entry: EntryConfig) {
   const { css, map } = getOut(src, out, i.from);
   await writeFile(css, i.result.css);
   if (i.result.map) {
-    await writeFile(map, i.result.map);
+    await writeFile(map, typeof i.result.map === 'object' ? i.result.map.toString() : i.result.map);
   }
   return i;
 }


### PR DESCRIPTION
morgn meister 😉 

hoffe dir gehts gut soweit 🙂 

mit node 14 hat sich offensichtlich was getan an den SourceMaps, so dass an der stelle eine Instanz von SourceMapGenerator übergeben wird. 